### PR TITLE
Update Docker.md - /bin/bash to /bin/sh

### DIFF
--- a/content/SCALE/SCALETutorials/Apps/Docker.md
+++ b/content/SCALE/SCALETutorials/Apps/Docker.md
@@ -160,7 +160,7 @@ In the Scale UI, go to **System Settings > Shell** to begin entering commands:
 
 To view container namespaces: `k3s kubectl get namespaces`.
 To view pods by namespace: `k3s kubectl get -n <NAMESPACE> pods`.
-To access container shell: `k3s kubectl exec -n <NAMESPACE> --stdin --tty <POD> -- /bin/bash`.
+To access container shell: `k3s kubectl exec -n <NAMESPACE> --stdin --tty <POD> -- /bin/sh`.
 
 {{< expand "Additional Container Commands" >}}
 * View details about all containers: `k3s kubectl get pods,svc,daemonsets,deployments,statefulset,sc,pvc,ns,job --all-namespaces -o wide`.


### PR DESCRIPTION
changed:
k3s kubectl exec -n <NAMESPACE> --stdin --tty <POD> -- /bin/bash

to

/bin/sh

Original command (/bin/bash) was giving out an error: "No such file or directory: unknown command..."



Thanks for contributing to TrueNAS documentation! By opening a Pull Request, you're acknowledging that your changes will be distributed under the [Creative Commons 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license.
